### PR TITLE
Fine-tune licensing side-word desktop positioning

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5123,7 +5123,7 @@ input, select, textarea {
 	display: inline-flex;
 
 	position: absolute;
-	right: 53%;
+	right: 52%;
 	width: 100%;
 	max-width: 5.75em;
 	padding-left: 0.5em;


### PR DESCRIPTION
shortened gap between .licensing-side-word and LICENSING text